### PR TITLE
Add scripts to support scripted and embedded dashboards

### DIFF
--- a/public/dashboards/embed.js
+++ b/public/dashboards/embed.js
@@ -1,0 +1,273 @@
+//# sourceURL=embed.js
+// The marker above helps Google Chrome to find the source code in Developer Console (https://developer.mozilla.org/en-US/docs/Tools/Debugger/How_to/Debug_eval_sources)
+// accessable variables in this scope
+var window, document, ARGS, $, jQuery, moment, kbn, _, services;
+
+var constructDashboardAsync = function (callbackFunction) {
+
+  if (!ARGS) {
+    ARGS = {};
+  }
+
+  var downsampleIntTemplate = {
+    "type": "interval",
+    "datasource": null,
+    "hide": 2,
+    "refresh_on_load": false,
+    "name": "downsampleInt",
+    "options": [
+      {
+        "text": "auto",
+        "value": "$__auto_interval"
+      },
+      {
+        "text": "1m",
+        "value": "1m"
+      },
+      {
+        "text": "10m",
+        "value": "10m"
+      },
+      {
+        "text": "30m",
+        "value": "30m"
+      },
+      {
+        "text": "1h",
+        "value": "1h"
+      },
+      {
+        "text": "6h",
+        "value": "6h"
+      },
+      {
+        "text": "12h",
+        "value": "12h"
+      },
+      {
+        "text": "1d",
+        "value": "1d"
+      },
+      {
+        "text": "7d",
+        "value": "7d"
+      },
+      {
+        "text": "14d",
+        "value": "14d"
+      },
+      {
+        "text": "30d",
+        "value": "30d"
+      }
+    ],
+    "includeAll": false,
+    "allFormat": "glob",
+    "query": "1m,10m,30m,1h,6h,12h,1d,7d,14d,30d",
+    "auto": true,
+    "current": {
+      "text": "1m",
+      "value": "1m"
+    },
+    "auto_count": 200
+  };
+
+  function loadDashboard() {
+    var result = {
+      "title": "Metrics Overview",
+      "time": {
+        "from": "now-1h",
+        "to": "now"
+      },
+      "rows": [
+        {
+          "title": "",
+          "height": "600px",
+          "editable": false,
+          "collapse": false,
+          "showTitle": false,
+          "panels": [
+            {
+              "id": 0,
+              "span": 12,
+              "editable": false,
+              "type": "graph",
+              "renderer": "flot",
+              "x-axis": true,
+              "y-axis": true,
+              "scale": 1,
+              "y_formats": [
+                "gscustom",
+                "none"
+              ],
+              "lines": true,
+              "fill": 0,
+              "linewidth": 2,
+              "points": false,
+              "pointradius": 5,
+              "bars": false,
+              "stack": false,
+              "percentage": false,
+              "legend": {
+                "show": true,
+                "values": true,
+                "min": false,
+                "max": false,
+                "current": false,
+                "total": false,
+                "avg": false,
+                "hideEmpty": false,
+                "alignAsTable": false,
+                "rightSide": false
+              },
+              "nullPointMode": "connected",
+              "steppedLine": false,
+              "tooltip": {
+                "value_type": "cumulative",
+                "shared": false
+              },
+              "seriesOverrides": [],
+              "links": [],
+              "leftYAxisLabel": "",
+              "targets": [],
+              "title": ""
+            }
+          ]
+        }
+      ],
+      "templating": {
+        "list": [ ],
+        "enable": true
+      }
+    };
+
+    // Auto-downsampling template
+    result.templating.list.push(downsampleIntTemplate);
+
+    // construct target from ARGS
+    setTimeRange(result);
+
+    if (result.rows[0] && ARGS.height) {
+      result.rows[0].height = ARGS.height;
+    }
+
+    var panel = result.rows[0].panels[0];
+    customizePanel(panel)
+    
+    if (ARGS.targets) {
+      // Example usage : http://grafana-url.com/#/dashboard/script/embed.js?targets=%5B%7B%22domain%22:%22system%22,%22asset%22:%22nds1630358.com%22,%22metric%22:%22ENDPOINT.Processor.PercentUserTime%22%7D%5D&startTime=now-6h&endTime=now&chartTitle=CPU%20Usage&embed&fullscreen&panelId=1
+      // Show multiple lines via target arguments
+      var targets = JSON.parse(ARGS.targets);
+      for (var i=0; i<targets.length; ++i) {
+        var defaultTarget = newTarget();
+        var originalTarget = targets[i];
+        var target = Object.assign(defaultTarget, undefined, originalTarget);
+        if (target.domain && target.asset && target.metric) {
+          enrichAliasIfMissing(target);
+          addTarget(target, panel);
+        } else {
+          console.log("Invalid target: domain, asset or metric is empty", target);
+        }
+      }
+    } else {
+      var target = newTarget();
+      setTargetProperties(target);
+      addTarget(target, panel);
+    }
+    callbackFunction(result);
+  }
+
+  function enrichAliasIfMissing(target) {
+    if (! target.alias) {
+      // Create simple alias if it's not specified. E.g., vmhost-123.com:UNIX.CPU.pct_used{"disk":"/local"}
+      target.alias = target.asset + ':' + target.metric;
+      if (! _.isEmpty(target.tags)) {
+        target.alias += JSON.stringify(target.tags);
+      }
+    }
+  }
+
+  function setTargetProperties(target) {
+    if (ARGS.aggregator) {
+      target.aggregator = ARGS.aggregator;
+    }
+
+    if (ARGS.downsampleagg) {
+      target.downsampleAggregator = ARGS.downsampleagg;
+      target.shouldDownsample = true;
+    }
+
+    if (ARGS.downsampleInterval && ARGS.downsamplePeriod) {
+      target.downsampleInterval = ARGS.downsampleInterval + ARGS.downsamplePeriod;
+      target.shouldDownsample = true;
+    }
+
+    if (ARGS.isRate == true) {
+      target.shouldComputeRate = true;
+    }
+
+    if (ARGS.asset) {
+      target.asset = ARGS.asset;
+    }
+
+    if (ARGS.metric) {
+      target.alias = ARGS.metric;
+      target.metric = ARGS.metric;
+    }
+
+    if (ARGS.domain) {
+      target.domain = ARGS.domain;
+    }
+
+    if (ARGS.tags) {
+      target.tags = JSON.parse(decodeURI(ARGS.tags));
+    }
+
+    if (ARGS.formula) {
+      target.isFormula = true;
+      target.formula = ARGS.formula;
+    }
+  }
+
+  function newTarget() {
+    return {
+      "errors": {},
+      "aggregator": "avg",
+      "downsampleAggregator": "avg",
+      "asset": "",
+      "metric": "",
+      "shouldDownsample": true,
+      "downsampleInterval": "$downsampleInt",
+      "tags": {},
+      "alias": ""
+    }
+  }
+
+  function addTarget(target, panel) {
+    panel.targets.push(target);
+  }
+
+  function setTimeRange(dashboard) {
+    if (ARGS.startTime) {
+      dashboard.time.from = ARGS.startTime;
+    }
+
+    if (ARGS.endTime) {
+      dashboard.time.to = ARGS.endTime;
+    }
+  }
+
+  function customizePanel(panel) {
+    if (!_.isUndefined(ARGS.metricCategory)) {
+      panel.title = ARGS.metricCategory + " " + ARGS.metric;
+    } else if (!_.isUndefined(ARGS.chartTitle)) {
+      panel.title = ARGS.chartTitle;
+    } else {
+      panel.title = ARGS.asset + " - " + ARGS.metric;
+    }
+  }
+
+  loadDashboard();
+};
+
+return constructDashboardAsync;

--- a/public/dashboards/script.js
+++ b/public/dashboards/script.js
@@ -1,0 +1,340 @@
+//# sourceURL=script.js
+// The marker above helps Google Chrome to find the source code in Developer Console (https://developer.mozilla.org/en-US/docs/Tools/Debugger/How_to/Debug_eval_sources)
+// accessable variables in this scope
+
+var window, document, ARGS, $, jQuery, moment, kbn, _, services;
+
+var sysdigService = function($) {
+  var uniquePanelId = 0;
+  var backendId = ARGS['backend'];
+  var backend = "default";
+
+  if (backendId.match("prod[2-9]$")) {
+    backend = "Sysdig Prod" + backendId.at(4);
+  } else if (backendId == "prod1") {
+    backend = "Sysdig Prod";
+  }
+  var createDefaultSysdigTarget = function(custom) {
+    var target = {
+      "datasource": backend,
+      "groupAggregation": "avg",
+      "isTabularFormat": false,
+      "pageLimit": "10",
+      "segmentBy": [],
+      "timeAggregation": "timeAvg"
+    };
+    _(["filter", "target"]).forEach(function(requiredField) {
+      if (! custom.hasOwnProperty(requiredField)) {
+        console.log("Following argument to createDefaultSysdigTarget is missing required field", custom);
+        throw new Error("createDefaultTarget takes an object with field "+ requiredField);
+      }
+    });
+    $.extend(target, custom);
+    return target;
+  };
+
+  var createDefaultSysdigPanel = function(custom) {
+    var panel = {
+      "id": uniquePanelId++,
+      "aliasColors": {},
+      "datasource": backend,
+      "fill": 1,
+      "fillGradient": 0,
+      "span": 6,
+      "hiddenSeries": false,
+      "legend": {
+        "alignAsTable": false,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "nullPointMode": "null",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": true,
+      "steppedLine": false,
+      "targets": [],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "Default Panel",
+      "tooltip": {},
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "percent",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": "0",
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    };
+    $.extend(panel, custom);
+    return panel;
+  };
+
+  var createDefaultSysdigRow = function(custom) {
+    var row = {
+      "title": "Default",
+      "height": "300px",
+      "editable": true,
+      "collapse": true,
+      "showTitle": true,
+      "panels": []
+    };
+    $.extend(row, custom);
+    return row;
+  };
+
+  return {
+    createDefaultSysdigPanel: createDefaultSysdigPanel,
+    createDefaultSysdigRow: createDefaultSysdigRow,
+    createDefaultSysdigTarget: createDefaultSysdigTarget
+  };
+};
+
+var pulseService = function($) {
+  var uniquePanelId = 0;
+  var createDefaultTarget = function(custom) {
+    var target = {
+      "aggregator": "avg",
+      "downsampleAggregator": "avg",
+      "shouldDownsample": true,
+      "downsampleInterval": "5m",
+      "tags": {
+      },
+      "shouldComputeRate": false,
+      "isCounter": false
+    };
+
+    _(["domain", "asset", "metric"]).forEach(function(requiredField) {
+      if (! custom.hasOwnProperty(requiredField)) {
+        console.log("Following argument to createDefaultTarget is missing required field", custom);
+        throw new Error("createDefaultTarget takes an object with field "+ requiredField);
+      }
+    });
+    $.extend(target, custom);
+    return target;
+  };
+
+  var createDefaultPanel = function(custom) {
+    var panel = {
+      // Each panel requires unique ID in Grafana
+      "id": uniquePanelId++,
+      "title": "Default Panel",
+      "span": 6,
+      "type": "graph",
+      "x-axis": true,
+      "y-axis": true,
+      "scale": 1,
+      "y_formats": [
+        "percent",
+        "none"
+      ],
+      "grid": {
+        "max": null,
+        "min": null,
+        "leftMax": 100,
+        "rightMax": null,
+        "leftMin": 0,
+        "rightMin": null,
+        "threshold1": null,
+        "threshold2": null,
+        "threshold1Color": "rgba(216, 200, 27, 0.27)",
+        "threshold2Color": "rgba(234, 112, 112, 0.22)",
+        "thresholdLine": false
+      },
+      "resolution": 100,
+      "lines": true,
+      "fill": 0,
+      "linewidth": 2,
+      "points": false,
+      "pointradius": 5,
+      "bars": false,
+      "stack": false,
+      "spyable": true,
+      "options": false,
+      "legend": {
+        "show": true,
+        "values": true,
+        "min": false,
+        "max": false,
+        "current": true,
+        "total": false,
+        "avg": true,
+        "hideEmpty": false,
+        "alignAsTable": true
+      },
+      "interactive": true,
+      "legend_counts": true,
+      "timezone": "browser",
+      "percentage": false,
+      "nullPointMode": "null as zero",
+      "steppedLine": false,
+      "tooltip": {
+        "value_type": "individual",
+        "query_as_alias": true,
+        "shared": false
+      },
+      "targets": [],
+      "renderer": "flot",
+      "annotate": {
+        "enable": false
+      },
+      "seriesOverrides": [],
+      "leftYAxisLabel": "sample label",
+      "links": []
+    };
+    $.extend(panel, custom);
+    return panel;
+  };
+
+  var createHtmlPanel = function(custom) {
+    var panel = {
+      id: uniquePanelId++,
+      span: 12,
+      type: "text",
+      mode: "html",
+      style: {},
+      links: [],
+      title: "Default HTML panel",
+      content: "<p><a href='pulse.gs.com'>Pulse</a> default HTML panel</p>"
+    };
+    $.extend(panel, custom);
+    return panel;
+  };
+
+  var createDefaultRow = function(custom) {
+    var row = {
+      "title": "Default",
+      "height": "300px",
+      "editable": true,
+      "collapse": true,
+      "showTitle": true,
+      "panels": []
+    };
+    $.extend(row, custom);
+    return row;
+  };
+
+  return {
+    createDefaultPanel: createDefaultPanel,
+    createHtmlPanel: createHtmlPanel,
+    createDefaultRow: createDefaultRow,
+    createDefaultTarget: createDefaultTarget
+  };
+};
+
+var constructDashboardAsync = function (callbackFunction) {
+  // Example value: "user/dashboardHost"
+  var dashboardId = ARGS['dashboard'];
+
+  // https://grafana-url.com/api/datasources/proxy/1/grafana/script/user/dashboardHost
+  var url = '/api/datasources/proxy/1/grafana/script/'+dashboardId;
+  $.ajax({
+    method: 'GET',
+    url: url
+  }).done(function(scriptedDashboardApiResult) {
+    executeScriptedDashboard(scriptedDashboardApiResult, callbackFunction);
+  });
+};
+
+var executeScriptedDashboard = function(scriptedDashboardApiResult, callbackFunction) {
+  // The result is from GrafanaController.getScriptedDashboard
+  if (! scriptedDashboardApiResult) {
+      console.log("Scripted dashboard returned empty for URL" + url);
+      return;
+  }
+  environmentConfig = {
+      pulseApiBaseUrl: '/api/datasources/proxy/1'
+  };
+  var scriptBody = scriptedDashboardApiResult.script;
+  var scriptFunc = new Function('ARGS', 'kbn', '_', 'moment', 'window', 'document', '$', 'jQuery', 'services', scriptBody);
+  var servicesForFunc = {
+    pulseService: pulseService($),
+    sysdigService: sysdigService($)
+  };
+  var scriptResult = scriptFunc(ARGS, kbn, _, moment, window, document, $, $, servicesForFunc);
+
+  // Handle async dashboard scripts
+  var dashboardPromise;
+  if (_.isFunction(scriptResult)) {
+    try {
+      dashboardPromise = new Promise(resolve => {
+        scriptResult(function (dashboard) {
+          resolve({data: dashboard});
+        });
+      });
+    } catch (e) {
+      console.log('Caught an error', e);
+    }
+    //dashboardPromise = promise;
+  } else {
+    dashboardPromise = Promise.resolve({ data: scriptResult });
+  }
+  dashboardPromise.then(function(scriptedDashboardResult) {
+      handleScriptedDashboardResult(scriptedDashboardResult, callbackFunction);
+    },
+    function(err) {
+        console.log("Failed to resolve promise", err);
+    });
+};
+
+var handleScriptedDashboardResult = function (scriptedDashboardResult, callbackFunction) {
+  var dashboardObj = scriptedDashboardResult.data;
+  // This API converts Grafana1 dashboard to Grafana5
+  var dashboardConvertUrl = '/api/datasources/proxy/1/grafana/dashboards/convert';
+  if (dashboardObj.panels) {
+    // In case the function already returns Grafana 5 Dashboard object, then
+    // we don't need to call
+    callbackFunction(dashboardObj);
+  } else {
+    $.ajax({
+      method: 'POST',
+      url: dashboardConvertUrl,
+      data: JSON.stringify(dashboardObj),
+      contentType: 'application/json'
+    }).done(function(convertedDashboard) {
+      callbackFunction(convertedDashboard);
+    }).fail(function(jqXHR, textStatus){
+      console.log("Failed to call convert API", textStatus, jqXHR);
+    });
+  }
+};
+
+return constructDashboardAsync;


### PR DESCRIPTION
What is this feature?

Support for custom scripted and embedded dashboards for Pulse. This enable GS internal teams to embed pulse charts in their websites and also create dashboards from scripts.

Why do we need this feature?

GS internal teams have been using scripted and embedded dashboards, in order for them to move to gsoss Grafana we need to add this feature

Who is this feature for?

Pulse Grafana users

