### PR TITLE
disable api/v1/rules call in init for prometheus datasource

### DIFF
--- a/public/app/plugins/datasource/prometheus/datasource.tsx
+++ b/public/app/plugins/datasource/prometheus/datasource.tsx
@@ -150,7 +150,6 @@ export class PrometheusDatasource
   }
 
   init = async () => {
-    this.loadRules();
     this.exemplarsAvailable = await this.areExemplarsAvailable();
   };
 
@@ -1093,20 +1092,6 @@ export class PrometheusDatasource
 
   getInitHints() {
     return getInitHints(this);
-  }
-
-  async loadRules() {
-    try {
-      const res = await this.metadataRequest('/api/v1/rules', {}, { showErrorAlert: false });
-      const groups = res.data?.data?.groups;
-
-      if (groups) {
-        this.ruleMappings = extractRuleMappingFromGroups(groups);
-      }
-    } catch (e) {
-      console.log('Rules API is experimental. Ignore next error.');
-      console.error(e);
-    }
   }
 
   async areExemplarsAvailable() {


### PR DESCRIPTION
What is this feature?

Disable Rules API call from Prometheus data source in Grafana. The call is made to auto-suggest metrics when writing a query.

Why do we need this feature?

Call to Rules API is heavy and leads to significant load time for users. Disabling the calls leads to a better user experience. 

Who is this feature for?

Pulse Grafana users