### PR TITLE
disable backdrop-filter as it slows rendering

### DIFF
--- a/packages/grafana-ui/src/components/Drawer/Drawer.tsx
+++ b/packages/grafana-ui/src/components/Drawer/Drawer.tsx
@@ -186,7 +186,7 @@ const getStyles = (theme: GrafanaTheme2) => {
     `,
     mask: css`
       background-color: ${theme.components.overlay.background} !important;
-      backdrop-filter: blur(1px);
+      backdrop-filter: blur(0px);
     `,
     maskMotion: css`
       &-appear {

--- a/packages/grafana-ui/src/components/Modal/getModalStyles.ts
+++ b/packages/grafana-ui/src/components/Modal/getModalStyles.ts
@@ -36,7 +36,7 @@ export const getModalStyles = stylesFactory((theme: GrafanaTheme2) => {
       bottom: 0;
       left: 0;
       background-color: ${theme.components.overlay.background};
-      backdrop-filter: blur(1px);
+      backdrop-filter: blur(0px);
     `,
     modalHeader: css`
       label: modalHeader;

--- a/public/app/core/components/MegaMenu/NavBarMenu.tsx
+++ b/public/app/core/components/MegaMenu/NavBarMenu.tsx
@@ -105,7 +105,7 @@ const getStyles = (theme: GrafanaTheme2, searchBarHidden?: boolean) => {
 
   return {
     backdrop: css({
-      backdropFilter: 'blur(1px)',
+      backdropFilter: 'blur(0px)',
       backgroundColor: theme.components.overlay.background,
       bottom: 0,
       left: 0,

--- a/public/app/core/components/NavBar/NavBarMenu.tsx
+++ b/public/app/core/components/NavBar/NavBarMenu.tsx
@@ -105,7 +105,7 @@ NavBarMenu.displayName = 'NavBarMenu';
 
 const getStyles = (theme: GrafanaTheme2) => ({
   backdrop: css({
-    backdropFilter: 'blur(1px)',
+    backdropFilter: 'blur(0px)',
     backgroundColor: theme.components.overlay.background,
     bottom: 0,
     left: 0,

--- a/public/app/features/commandPalette/CommandPalette.tsx
+++ b/public/app/features/commandPalette/CommandPalette.tsx
@@ -148,7 +148,7 @@ const getSearchStyles = (theme: GrafanaTheme2) => {
         bottom: 0,
         left: 0,
         background: theme.components.overlay.background,
-        backdropFilter: 'blur(1px)',
+        backdropFilter: 'blur(0px)',
       },
     }),
     animator: css({

--- a/public/app/features/search/components/DashboardSearchModal.tsx
+++ b/public/app/features/search/components/DashboardSearchModal.tsx
@@ -148,7 +148,7 @@ const getStyles = (theme: GrafanaTheme2) => {
   return {
     underlay: css`
       background-color: ${theme.components.overlay.background};
-      backdrop-filter: blur(1px);
+      backdrop-filter: blur(0px);
       bottom: 0;
       left: 0;
       padding: 0;


### PR DESCRIPTION
<!--

Thank you for sending a pull request! Here are some tips:

1. If this is your first time, please read our contribution guide at https://github.com/grafana/grafana/blob/main/CONTRIBUTING.md

2. Ensure you include and run the appropriate tests as part of your Pull Request.

3. In a new feature or configuration option, an update to the documentation is necessary. Everything related to the documentation is under the docs folder in the root of the repository.

4. If the Pull Request is a work in progress, make use of GitHub's "Draft PR" feature and mark it as such.

5. If you can not merge your Pull Request due to a merge conflict, Rebase it. This gets it in sync with the main branch.

6. Name your PR as "<FeatureArea>: Describe your change", e.g. Alerting: Prevent race condition. If it's a fix or feature relevant for the changelog describe the user impact in the title. The PR title is used to auto-generate the changelog for issues marked with the "add to changelog" label.

7. If your PR content should be added to the What's New document for the next major or minor release, add the **add to what's new** label to your PR. Note that you should add this label to the main PR that introduces the feature; do not add this label to smaller PRs for the feature.

-->

**What is this feature?**

Disable blur css to reduce compute time spent in blurring 

**Why do we need this feature?**

UI has been slow due to backdrop-filter for modal and drawer components which leads to bad user experience, also described [here](https://github.com/grafana/grafana/issues/100859)

**Who is this feature for?**

Disable backdrop filter for Modal and Drawer UI components
